### PR TITLE
fix: write token file to home directory instead of CWD

### DIFF
--- a/kroger_api/client.py
+++ b/kroger_api/client.py
@@ -92,7 +92,9 @@ class KrogerClient:
             The token information
         """
         # Set the token file for this scope
-        self.token_file = f".kroger_token_client_{scope.replace(':', '_')}.json"
+        _token_dir = os.environ.get('KROGER_TOKEN_DIR')
+        _token_name = f".kroger_token_client_{scope.replace(':', '_')}.json"
+        self.token_file = os.path.join(_token_dir if _token_dir else os.path.expanduser('~'), _token_name)
         
         # Try to load an existing token first
         token_info = load_token(self.token_file)


### PR DESCRIPTION
## Problem

Fixes #6

When running `kroger-api` from an environment where the current working directory is read-only (e.g. Claude Desktop on Windows, which is a Windows Store app that spawns MCP server processes with CWD set to `C:\Windows\System32\`), the token file write fails with:

```
[Errno 13] Permission denied: '.kroger_token_client_product.compact.json'
```

## Fix

- Fall back to `os.path.expanduser('~')` (home directory) instead of CWD, writable on all platforms (Windows, macOS, Linux)
- Support an optional `KROGER_TOKEN_DIR` env var for explicit control over token file location

## Behavior

| Scenario | Before | After |
|----------|--------|-------|
| Normal CWD (writable) | Works, token in CWD | Works, token in `~` |
| Read-only CWD (e.g. Windows Store app) | `Permission denied` | Works, token in `~` |
| `KROGER_TOKEN_DIR` set | Not supported | Token written to specified dir |

## Testing

Verified on Windows with Claude Desktop (Windows Store app), where CWD is `C:\Windows\System32\`.
